### PR TITLE
Update ndarray to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/clearlycloudy/dt/"
 readme = "README.md"
 
 [dependencies]
-ndarray = "0.13.1"
+ndarray = "0.15"
 num = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Hi!

Thanks for your dt implementation, its helping me a lot with my current project. 
Sadly the crate currently is not compatible with the newest version of ndarray, therefore i bumped its version to 0.15. The functionality that dt uses doesnt seem to have changed since 0.13.1 and all tests pass.